### PR TITLE
Clarifying deployment instructions in README

### DIFF
--- a/HabitatHome.Commerce.sln
+++ b/HabitatHome.Commerce.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27004.2009
@@ -10,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configurat
 		gulp-config.js = gulp-config.js
 		gulpfile.js = gulpfile.js
 		nuget.config = nuget.config
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Project", "Project", "{EC07E32B-7A0D-4C4D-941D-43DAC3AE2601}"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The code, samples and/or solutions provided in this repository are for example p
 
 # Getting Started
 
+**This guide assumes you've cloned and deployed Sitecore.HabitatHome.Content. See the README.md file in the [Sitecore.HabitatHome.Content](https://github.com/sitecore/sitecore.habitathome.content) repository.**
+
 ## Prerequisites
 
 ### Sitecore Version
@@ -34,25 +36,29 @@ If you do **not want to use the default settings**, you need to adjust the appro
 
 `/gulp-config.js` 
 `/publishsettings.targets` 
-`src\Project\HabitatHome\code\App_Config\Include\Project\z.HabitatHome.Commerce.WebSite.DevSettings.config`
+`src\Project\HabitatHome\website\App_Config\Include\Project\z.HabitatHome.Commerce.WebSite.DevSettings.config`
+
+Note: If you've already deployed the HabitatHome Content demo, and you wish to run the HabitatHome Commerce demo in a new instance by customizing these sttings,
+you would need to also customize the settings in the HabitatHome Content demo and deploy it to the new instance **before** deploying HabitatHome Commerce. 
+See README.md in Sitecore.HabitatHome.Content for custom settings.
 
 ## Installation
 **All installation instructions assume using PowerShell 5.1 in administrative mode.**
+
 ### 1 Clone the Repository
 Clone the Sitecore.HabitatHome.Commerce repository locally - default settings assume **`C:\Projects\Sitecore.HabitatHome.Commerce`**. 
 
 `git clone https://github.com/Sitecore/Sitecore.HabitatHome.Commerce.git` or 
 `git clone git@github.com:Sitecore/Sitecore.HabitatHome.Commerce.git`
-
   
 ### 2 Deploy Solution
-From the root of the solution
+Note: If you have not yet done so, deploy the base HabitatHome.Content solution. See README.md in Sitecore.HabitatHome.Content
+You can run the `quick-deploy` gulp task from the root of the HabitatHome.Content solution for a quicker deploy that excludes post deploy actions or Unicorn synchronization.
+
+To deploy the HabitatHome.Commerce solution, from the root of the solution
 
 `npm install`
 `node_modules\.bin\gulp initial`
-
-> if using Visual Studio task runner, please see [this workaround](https://stackoverflow.com/questions/45580456/visual-studio-task-runner-error-with-es6)
-
 > gulp **initial** only needs to be executed successfully during the initial deployment. Subsequent deployments can be made by running the default gulp task (gulp with no parameters). 
 
 ### 3 Deploy Engine


### PR DESCRIPTION
Adding instructions that specify the need to deploy Sitecore.HabitatHome.Content PRIOR to deploying Sitecore.HabitatHome.Commerce.

Resolves #5 and #6 