### PR TITLE
removing domain portion of username from script

### DIFF
--- a/deploy-commerce-engine.ps1
+++ b/deploy-commerce-engine.ps1
@@ -94,7 +94,7 @@ Function Get-IdServerToken {
     $body = @{
         password   = "$adminPassword"
         grant_type = 'password'
-        username   = ("sitecore\{0}" -f $adminUser)
+        username   = ("{0}" -f $adminUser)
         client_id  = 'postman-api'
         scope      = 'openid EngineAPI postman_api'
     }


### PR DESCRIPTION
Removing domain 'sitecore' from deploy engine since it's being passed in as parameter now.

FYI @viethoangpyco 