### PR TITLE
HOTFIX - missing Active Promotion Rendering on PDP

### DIFF
--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/home/Shop/_/_.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/home/Shop/_/_.yml
@@ -57,8 +57,13 @@ Languages:
               s:par="GridParameters"
               s:ph="/main/column-1-2" />
             <r
-              uid="{62FB9058-126D-491B-B693-ED9A43DA577B}"
+              uid="{2AED6AD7-3AD6-44B3-AFD3-7837C3216C34}"
               p:after="r[@uid='{CD1F2857-06D5-475B-A22B-59A8CA828FD0}']"
+              s:id="{958D6FFB-6715-46CA-9670-683D422D2B58}"
+              s:ph="/main/column-1-2" />
+            <r
+              uid="{62FB9058-126D-491B-B693-ED9A43DA577B}"
+              p:after="r[@uid='{2AED6AD7-3AD6-44B3-AFD3-7837C3216C34}']"
               s:ds="{82F5250C-1122-43BD-A5BD-6959376CFFC3}"
               s:id="{B79DF484-3464-441A-811C-DC1BFEED8CA1}"
               s:par="GridParameters"


### PR DESCRIPTION
Rendering removed for troubleshooting wasn't re-added during a merge.