### PR TITLE
Fix for Issue #18. After upgrading Gulp to version 4 in 9.0.2 branch initial gulp task was not working as expected

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -190,7 +190,7 @@ gulp.task("quick-deploy",
             "Publish-Website-Projects",
             "Apply-Xml-Transform",
             "Publish-Transforms",
-            callback);
+            callback)();
     });
 
 gulp.task("initial",
@@ -205,7 +205,7 @@ gulp.task("initial",
             "Rebuild-Core-Index",
             "Rebuild-Master-Index",
             "Rebuild-Web-Index",
-            callback);
+            callback)();
     });
 
 gulp.task("publish",
@@ -216,7 +216,7 @@ gulp.task("publish",
             "Publish-All-Projects",
             "Apply-Xml-Transform",
             "Publish-Transforms",
-            callback);
+            callback)();
     });
 
 /*****************************


### PR DESCRIPTION
I was getting exception: "The following tasks did not complete: initial. Did you forget to signal async completion?"

This is a fix for Issue #18. After upgrading Gulp to version 4 in 9.0.2 branch, I was getting exception: "The following tasks did not complete: initial. Did you forget to signal async completion?"
