### PR TITLE
added missing en version for CommerceConnect Cart Total Condition

### DIFF
--- a/src/Foundation/Rules/serialization/System.Foundation.Rules.CartTotalCondition/Cart Total Condition.yml
+++ b/src/Foundation/Rules/serialization/System.Foundation.Rules.CartTotalCondition/Cart Total Condition.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "a5c43381-da2f-4c22-ab76-a1a3483590af"
+Parent: "9643f053-9a0c-4815-a6f8-a69192d3fca5"
+Template: "f0d16eee-3a05-4e43-a082-795a32b873c0"
+Path: /sitecore/system/Settings/Rules/Definitions/Elements/CommerceConnect Conditional Renderings/Cart Total Condition
+DB: master
+SharedFields:
+- ID: "ab51c8b2-f0e1-4471-9aae-cc080d774923"
+  Hint: Type
+  Value: Sitecore.Commerce.Engine.Connect.CartSubtotalCondition,Sitecore.Commerce.Engine.Connect
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20180813T145053Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+    - ID: "af321234-4eb9-4ef5-9197-65903351939c"
+      Hint: Text
+      Value: "where the user's cart total [operatorid,Operator,,compares to] [CartTotal,,defaultValue=&validationText=Please enter a valid positive decimal value.,specific value]"

--- a/src/Foundation/Rules/website/App_Config/Include/Foundation/Commerce/Foundation.Rules.Serialization.config
+++ b/src/Foundation/Rules/website/App_Config/Include/Foundation/Commerce/Foundation.Rules.Serialization.config
@@ -14,6 +14,7 @@
                         <include name="System.Foundation.Rules.PromotionByLocation" database="master" path="/sitecore/system/Settings/Rules/Definitions/Elements/CommerceConnect Conditional Renderings/Promotion By Location Condition" />
                         <include name="System.Foundation.Rules.HasPurchasedProductCondition" database="master" path="/sitecore/system/Settings/Rules/Definitions/Elements/CommerceConnect Conditional Renderings/Has Purchased Product Condition" />
                         <include name="System.Foundation.Rules.HasNotPurchasedProductCondition" database="master" path="/sitecore/system/Settings/Rules/Definitions/Elements/CommerceConnect Conditional Renderings/Has Not Purchased Product Condition" />
+                        <include name="System.Foundation.Rules.CartTotalCondition" database="master" path="/sitecore/system/Settings/Rules/Definitions/Elements/CommerceConnect Conditional Renderings/Cart Total Condition" />
 
                     </predicate>
 


### PR DESCRIPTION
The CommerceConnect Cart Total Condition is missing an 'en' version in the OOTB install, so the personalization rule is not available.
