### PR TITLE
Bug/offline orders

### DIFF
--- a/src/Feature/Orders/engine/Controllers/CommandsController.cs
+++ b/src/Feature/Orders/engine/Controllers/CommandsController.cs
@@ -42,12 +42,13 @@ namespace Sitecore.HabitatHome.Feature.Orders.Engine.Controllers
         [HttpPut]
         [Route("CreateOfflineOrder()")]
         public async Task<string> CreateOfflineOrder([FromBody] ODataActionParameters value)
-        {
-            //var id = value["Id"].ToString();
+        {                                              
             var command = this.Command<CreateOfflineOrderCommand>();
 
             if (!value.ContainsKey("Order"))
-                return "Bad Request, Cannot Find Order key"; 
+            {
+                return "Bad Request, Cannot Find Order key";
+            } 
 
             var inputArgs = JsonConvert.DeserializeObject<OfflineStoreOrderArgument>(value["Order"].ToString());
 

--- a/src/Feature/Orders/engine/Pipelines/Arguments/OfflineOrderLine.cs
+++ b/src/Feature/Orders/engine/Pipelines/Arguments/OfflineOrderLine.cs
@@ -1,0 +1,17 @@
+﻿using System; 
+
+namespace Sitecore.HabitatHome.Feature.Orders.Engine.Pipelines.Arguments
+{
+    public class OfflineOrderLine
+    {
+        public string ItemId { get; set; }
+
+        public decimal Quantity { get; set; }
+
+        public string ProductName { get; set; }
+
+        public decimal UnitListPrice { get; set; }
+
+        public decimal SubTotal { get; set; }
+    }
+}

--- a/src/Feature/Orders/engine/Pipelines/Arguments/OfflineStoreOrderArgument.cs
+++ b/src/Feature/Orders/engine/Pipelines/Arguments/OfflineStoreOrderArgument.cs
@@ -12,46 +12,46 @@ namespace Sitecore.HabitatHome.Feature.Orders.Engine.Pipelines.Arguments
         }
 
         public string ShopName { get; set; }
+
         public string OrderConfirmationId { get; set; }
+
         public string OrderPlacedDate { get; set; }
+
         public string Email { get; set; }
+
+        public string Domain { get; set; }
+
         public string Language { get; set; }
+
         public string Status { get; set; }
+
         public string CurrencyCode { get; set; }
+
         public decimal SubTotal { get; set; }
+
         public decimal GrandTotal { get; set; }
+
         public decimal TaxTotal { get; set; }
+
         public decimal Discount { get; set; }       
+
         public string PaymentInstrumentType { get; set; }
+
         public string CardType { get; set; }
+
         public string MaskedNumber { get; set; }
+
         public int ExpiresMonth { get; set; }
+
         public int ExpiresYear { get; set; }
+
         public string TransactionStatus { get; set; }
+
         public string TransactionId { get; set; }
+
         public List<OfflineOrderLine> Lines { get; set; }
-        public Store StoreDetails { get; set; }
 
-
-    }
-
-    public class OfflineOrderLine
-    {
-        public string ItemId { get; set; }
-        public decimal Quantity { get; set; }
-        public string ProductName { get; set; }
-        public decimal UnitListPrice { get; set; }
-        public decimal SubTotal { get; set; }
-    }
-
-    public class Store
-    {
-        public string Name { get; set; }
-        public string Address { get; set; }
-        public string City { get; set; }
-        public string State { get; set; }
-        public string ZipCode { get; set; }
-        public string Country { get; set; }
+        public Store StoreDetails { get; set; }        
     }
 }
 

--- a/src/Feature/Orders/engine/Pipelines/Arguments/Store.cs
+++ b/src/Feature/Orders/engine/Pipelines/Arguments/Store.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Sitecore.HabitatHome.Feature.Orders.Engine.Pipelines.Arguments
+{
+    public class Store
+    {
+        public string Name { get; set; }
+
+        public string Address { get; set; }
+
+        public string City { get; set; }
+
+        public string State { get; set; }
+
+        public string ZipCode { get; set; }
+
+        public string Country { get; set; }
+    }
+}

--- a/src/Feature/Orders/engine/SampleData/PostmanOfflineOrder.json
+++ b/src/Feature/Orders/engine/SampleData/PostmanOfflineOrder.json
@@ -3,6 +3,7 @@
     "OrderPlacedDate": "2018-02-14T22:32:41.5332063+00:00",
     "OrderConfirmationId": "610003123232",
     "Email": "prasa@gmail.com",
+    "Domain": "CommerceUsers", 
     "Language": "en-US",
     "Status": "StoreOrder",
     "Lines": [

--- a/src/Feature/Orders/engine/SampleData/SampleUploadOrdersMultiple.json
+++ b/src/Feature/Orders/engine/SampleData/SampleUploadOrdersMultiple.json
@@ -4,6 +4,7 @@
       "OrderPlacedDate": "2018-02-14T22:32:41.5332063+00:00",
       "OrderConfirmationId": "509",
       "Email": "prasad@gmail.com",
+      "Domain": "CommerceUsers",
       "Language": "en-US",
       "Status": "StoreOrder",
       "Lines": [

--- a/src/Feature/Orders/engine/SampleData/SampleUploadSingleOrder.json
+++ b/src/Feature/Orders/engine/SampleData/SampleUploadSingleOrder.json
@@ -4,6 +4,7 @@
       "OrderPlacedDate": "2018-02-14T22:32:41.5332063+00:00",
       "OrderConfirmationId": "509",
       "Email": "prasad@gmail.com",
+      "Domain": "CommerceUsers",
       "Language": "en-US",
       "Status": "StoreOrder",
       "Lines": [

--- a/src/Feature/Orders/website/Utilities/UploadOrder.aspx.cs
+++ b/src/Feature/Orders/website/Utilities/UploadOrder.aspx.cs
@@ -191,6 +191,7 @@ namespace Sitecore.HabitatHome.Feature.Orders.Utilities
         public string OrderConfirmationId { get; set; }
         public string OrderPlacedDate { get; set; }
         public string Email { get; set; }
+        public string Domain { get; set; }
         public string Language { get; set; }
         public string Status { get; set; }
         public string CurrencyCode { get; set; }

--- a/src/Project/HabitatHome/engine/Sitecore.Commerce.Engine.csproj
+++ b/src/Project/HabitatHome/engine/Sitecore.Commerce.Engine.csproj
@@ -21,6 +21,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\Feature\Catalog\engine\Sitecore.HabitatHome.Feature.Catalog.Engine.csproj" />
+        <ProjectReference Include="..\..\..\Feature\Marketplace\engine\Sitecore.HabitatHome.Feature.EBay.Engine.csproj" />
         <ProjectReference Include="..\..\..\Feature\NearestStore\engine\Sitecore.HabitatHome.Feature.NearestStore.Engine.csproj" />
         <ProjectReference Include="..\..\..\Feature\Orders\engine\Sitecore.HabitatHome.Feature.Orders.Engine.csproj" />
         <ProjectReference Include="..\..\..\Feature\ProductBundle\engine\Sitecore.HabitatHome.Feature.ProductBundle.Engine.csproj" />
@@ -28,6 +29,7 @@
         <ProjectReference Include="..\..\..\Feature\WishLists\engine\Sitecore.HabitatHome.Feature.Wishlists.Engine.csproj" />
         <ProjectReference Include="..\..\..\Foundation\Entitlements\engine\Sitecore.HabitatHome.Foundation.Entitlements.Engine.csproj" />
         <ProjectReference Include="..\..\..\Foundation\Payments\engine\Sitecore.HabitatHome.Foundation.Payments.Engine.csproj" />
+        <ProjectReference Include="..\..\..\Foundation\PluginEnhancements\engine\Sitecore.HabitatHome.Foundation.PluginEnhancements.Engine.csproj" />
         <ProjectReference Include="..\..\..\Foundation\Rules\engine\Sitecore.HabitatHome.Foundation.Rules.Engine.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR is to fix issue #53 
In 9.0.2, customer IDs are prefixed with the storefront domain name. The current code was failing to find a customer without specifying the domain.
I've updated the sample import order json files to include a domain name as well